### PR TITLE
[squid:S1132] Strings literals should be placed on the left side when

### DIFF
--- a/auth-sdk/src/main/java/com/peaceful/auth/sdk/Impl/AuthServiceImpl.java
+++ b/auth-sdk/src/main/java/com/peaceful/auth/sdk/Impl/AuthServiceImpl.java
@@ -125,7 +125,7 @@ public class AuthServiceImpl implements com.peaceful.auth.sdk.api.AuthService {
         if (element == null) {
             String result = HttpUtils.get(publicServiceURL.user_info + email);
             boolean flag = true;
-            if (result.equals("null")) {
+            if ("null".equals(result)) {
                 clearSession(email);
                 flag = false;
             }
@@ -212,7 +212,7 @@ public class AuthServiceImpl implements com.peaceful.auth.sdk.api.AuthService {
         data.put("email", email);
         data.put("password", password);
         data.put("systemId", publicServiceURL.system_id);
-        return (HttpUtils.post(publicServiceURL.identification_email, data).equals("true") ? true : false);
+        return ("true".equals(HttpUtils.post(publicServiceURL.identification_email, data)) ? true : false);
     }
 
 

--- a/auth-sdk/src/main/java/com/peaceful/auth/sdk/util/APIRequestProxy.java
+++ b/auth-sdk/src/main/java/com/peaceful/auth/sdk/util/APIRequestProxy.java
@@ -43,7 +43,7 @@ public class APIRequestProxy {
                     pairs.add(new BasicNameValuePair(params1.name(), (String) args[i]));
                 }
                 String action = method1.action();
-                if (action.equals("get"))
+                if ("get".equals(action))
                     return HttpClient.get(url, pairs);
                 else
                     return HttpClient.post(url, pairs);

--- a/auth-spring/src/main/java/com/peaceful/auth/spring/MenuUtils.java
+++ b/auth-spring/src/main/java/com/peaceful/auth/spring/MenuUtils.java
@@ -102,10 +102,10 @@ public class MenuUtils extends TagSupport {
             return EVAL_BODY_INCLUDE;
         JspWriter out = this.pageContext.getOut();
         try {
-            if (menuLevel.equals("L1") || menuLevel.equals("L2")) {
-                if (menuLevel.equals("L1"))
+            if ("L1".equals(menuLevel) || "L2".equals(menuLevel)) {
+                if ("L1".equals(menuLevel))
                     out.print(getFirstLevelMenu(menuKey));
-                else if (menuLevel.equals("L2")) {
+                else if ("L2".equals(menuLevel)) {
                     if (StringUtils.isNotEmpty(otherAttr))
                         out.print(getSecondLevelMenu(menuKey, otherAttr, leftSpace));
                     else


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.
Ayman Abdelghany.
